### PR TITLE
fix: macro util timestamp/timespan kapi function wrappers 

### DIFF
--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -170,8 +170,8 @@ impl_katom! {KDateAtom, AtomType = KDate, KType = DATE_ATOM, Ctor = ki, Accessor
 impl_katom! {KDateTimeAtom, AtomType = KDateTime, KType = DATE_TIME_ATOM, Ctor = kf, Accessor: dt }
 impl_katom! {KSymbolAtom, AtomType = KSymbol, KType = SYMBOL_ATOM, Ctor = ks, Accessor: sym }
 impl_katom! {KGuidAtom, AtomType = KGuid, KType = GUID_ATOM, Ctor = ku, Accessor: u }
-impl_katom! {KTimestampAtom, AtomType = KTimestamp, KType = TIMESTAMP_ATOM, Ctor = kts, Accessor: tst }
-impl_katom! {KTimespanAtom, AtomType = KTimespan, KType = TIMESPAN_ATOM, Ctor = ktp, Accessor: ts }
+impl_katom! {KTimestampAtom, AtomType = KTimestamp, KType = TIMESTAMP_ATOM, Ctor = tst, Accessor: tst }
+impl_katom! {KTimespanAtom, AtomType = KTimespan, KType = TIMESPAN_ATOM, Ctor = tsp, Accessor: ts }
 
 //Extra convenience conversions implemented manually
 impl TryFrom<&str> for KSymbolAtom {

--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -170,8 +170,8 @@ impl_katom! {KDateAtom, AtomType = KDate, KType = DATE_ATOM, Ctor = ki, Accessor
 impl_katom! {KDateTimeAtom, AtomType = KDateTime, KType = DATE_TIME_ATOM, Ctor = kf, Accessor: dt }
 impl_katom! {KSymbolAtom, AtomType = KSymbol, KType = SYMBOL_ATOM, Ctor = ks, Accessor: sym }
 impl_katom! {KGuidAtom, AtomType = KGuid, KType = GUID_ATOM, Ctor = ku, Accessor: u }
-impl_katom! {KTimestampAtom, AtomType = KTimestamp, KType = TIMESTAMP_ATOM, Ctor = kj, Accessor: tst }
-impl_katom! {KTimespanAtom, AtomType = KTimespan, KType = TIMESPAN_ATOM, Ctor = kj, Accessor: ts }
+impl_katom! {KTimestampAtom, AtomType = KTimestamp, KType = TIMESTAMP_ATOM, Ctor = kts, Accessor: tst }
+impl_katom! {KTimespanAtom, AtomType = KTimespan, KType = TIMESPAN_ATOM, Ctor = ktp, Accessor: ts }
 
 //Extra convenience conversions implemented manually
 impl TryFrom<&str> for KSymbolAtom {

--- a/src/raw/kapi.rs
+++ b/src/raw/kapi.rs
@@ -2,6 +2,18 @@ use super::types::*;
 
 pub type KCallback = extern "C" fn(arg1: I) -> *const K;
 
+pub const K_NANO_OFFSET: i64   = 946_684_800_000_000_000;
+pub const K_TYPE_TIMESTAMP:i32 = -12;
+pub const K_TYPE_TIMESPAN:i32  = -16;
+
+pub fn tst(epoch_nanos:i64) -> *const K {
+      unsafe { ktj(K_TYPE_TIMESTAMP, epoch_nanos - K_NANO_OFFSET) }
+}
+
+pub fn tsp(epoch_nanos:i64) -> *const K {
+      unsafe { ktj(K_TYPE_TIMESPAN, epoch_nanos - K_NANO_OFFSET) }
+}
+
 #[cfg_attr(not(feature = "embedded"), link(name = "kdb"))]
 extern "C" {
     pub fn b9(mode: I, x: *const K) -> *const K;


### PR DESCRIPTION
+ automatic epoch offset